### PR TITLE
feat: use istio destination rules to allow for arbitrary SPIFFE IDs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,13 +110,13 @@ example-two-validate-signature: ## Validate OPA bundle signature
 
 .PHONY: example-two-deploy
 example-two-deploy: ## Deploy workloads for Istio and OPA example
-	$(MAKE) -C workload-1 apply
-	$(MAKE) -C workload-2 apply
+	$(MAKE) -C workload-1 deploy
+	$(MAKE) -C workload-2 deploy
 
 .PHONY: example-two-delete
 example-two-delete: example-two-opa-clean ## Delete workloads for Istio and OPA example
-	$(MAKE) -C workload-1 delete
-	$(MAKE) -C workload-2 delete
+	$(MAKE) -C workload-1 clean
+	$(MAKE) -C workload-2 clean
 
 .PHONY: example-two-check-istio-certs
 example-two-check-istio-certs: ## Show Istio issued certificates

--- a/istio/infra/opa-role.tf
+++ b/istio/infra/opa-role.tf
@@ -40,7 +40,7 @@ data "aws_iam_policy_document" "opa_assume_role_policy" {
       test     = "StringEquals"
       variable = "${local.spire_issuer}:sub"
       values = [
-        "spiffe://${var.spire_trust_domain}/ns/default/sa/${var.workload_one_sa}",
+        "spiffe://${var.spire_trust_domain}/${var.workload_one_sa}",
       ]
     }
   }
@@ -66,7 +66,7 @@ data "aws_iam_policy_document" "opa_assume_role_policy" {
       test     = "StringEquals"
       variable = "${local.spire_issuer}:sub"
       values = [
-        "spiffe://${var.spire_trust_domain}/ns/default/sa/${var.workload_two_sa}",
+        "spiffe://${var.spire_trust_domain}/${var.workload_two_sa}",
       ]
     }
   }

--- a/istio/infra/templates/example.rego
+++ b/istio/infra/templates/example.rego
@@ -5,25 +5,25 @@ import input.attributes.request.http as http_request
 default allow = false
 
 source_spiffe_id = spiffe_id {
-    [_, _, _, uri_type_san] := split(http_request.headers["x-forwarded-client-cert"], ";")
-    [_, spiffe_id] := split(uri_type_san, "=")
+	[_, _, _, uri_type_san] := split(http_request.headers["x-forwarded-client-cert"], ";")
+	[_, spiffe_id] := split(uri_type_san, "=")
 }
 
 destination_spiffe_id = source_id {
 	[s_id, _, _, _] := split(http_request.headers["x-forwarded-client-cert"], ";")
-  [_, source_id] := split(s_id, "=")
+	[_, source_id] := split(s_id, "=")
 }
 
 allow {
 	http_request.method == "GET"
-    destination_spiffe_id == "spiffe://${spire_trust_domain}/ns/default/sa/workload-1"
-    source_spiffe_id == "spiffe://${spire_trust_domain}/ns/default/sa/workload-2"
-    http_request.path == "/version"
+	destination_spiffe_id == "spiffe://${spire_trust_domain}/workload-1"
+	source_spiffe_id == "spiffe://${spire_trust_domain}/workload-2"
+	http_request.path == "/version"
 }
 
 allow {
 	http_request.method == "GET"
-    destination_spiffe_id == "spiffe://${spire_trust_domain}/ns/default/sa/workload-2"
-    source_spiffe_id == "spiffe://${spire_trust_domain}/ns/default/sa/workload-1"
-    http_request.path == "/metrics"
+	destination_spiffe_id == "spiffe://${spire_trust_domain}/workload-2"
+	source_spiffe_id == "spiffe://${spire_trust_domain}/workload-1"
+	http_request.path == "/metrics"
 }

--- a/s3-consumer/infra/target-bucket-federated-role.tf
+++ b/s3-consumer/infra/target-bucket-federated-role.tf
@@ -35,7 +35,7 @@ data "aws_iam_policy_document" "federated_assume_role_policy" {
       test     = "StringEquals"
       variable = "${local.spire_issuer}:sub"
       values = [
-        "spiffe://${var.spire_trust_domain}/ns/default/sa/${var.sa_name}",
+        "spiffe://${var.spire_trust_domain}/${var.sa_name}",
       ]
     }
   }

--- a/spire/infra/templates/cluster-spiffeid.yaml
+++ b/spire/infra/templates/cluster-spiffeid.yaml
@@ -3,7 +3,7 @@ kind: ClusterSPIFFEID
 metadata:
   name: example-workloads
 spec:
-  spiffeIDTemplate: "spiffe://${spire_trust_domain}/ns/{{ .PodMeta.Namespace }}/sa/{{ .PodSpec.ServiceAccountName }}"
+  spiffeIDTemplate: "spiffe://${spire_trust_domain}/{{ .PodSpec.ServiceAccountName }}"
   namespaceSelector:
     matchLabels:
       example: "true"

--- a/workload-1/Makefile
+++ b/workload-1/Makefile
@@ -1,3 +1,17 @@
+deploy: terraform-apply apply
+
+clean: delete terraform-destroy
+
+terraform-apply:
+	cd infra && \
+		$(TERRAFORM) init && \
+		$(TERRAFORM) apply \
+		-var spire_trust_domain=$(SPIRE_TRUST_DOMAIN) \
+		-auto-approve
+
+terraform-destroy:
+	cd infra && $(TERRAFORM) apply -auto-approve -destroy
+
 apply:
 	kubectl apply -f config
 

--- a/workload-1/infra/.terraform.lock.hcl
+++ b/workload-1/infra/.terraform.lock.hcl
@@ -1,0 +1,40 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/local" {
+  version     = "2.4.0"
+  constraints = "~> 2.4"
+  hashes = [
+    "h1:R97FTYETo88sT2VHfMgkPU3lzCsZLunPftjSI5vfKe8=",
+    "zh:53604cd29cb92538668fe09565c739358dc53ca56f9f11312b9d7de81e48fab9",
+    "zh:66a46e9c508716a1c98efbf793092f03d50049fa4a83cd6b2251e9a06aca2acf",
+    "zh:70a6f6a852dd83768d0778ce9817d81d4b3f073fab8fa570bff92dcb0824f732",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:82a803f2f484c8b766e2e9c32343e9c89b91997b9f8d2697f9f3837f62926b35",
+    "zh:9708a4e40d6cc4b8afd1352e5186e6e1502f6ae599867c120967aebe9d90ed04",
+    "zh:973f65ce0d67c585f4ec250c1e634c9b22d9c4288b484ee2a871d7fa1e317406",
+    "zh:c8fa0f98f9316e4cfef082aa9b785ba16e36ff754d6aba8b456dab9500e671c6",
+    "zh:cfa5342a5f5188b20db246c73ac823918c189468e1382cb3c48a9c0c08fc5bf7",
+    "zh:e0e2b477c7e899c63b06b38cd8684a893d834d6d0b5e9b033cedc06dd7ffe9e2",
+    "zh:f62d7d05ea1ee566f732505200ab38d94315a4add27947a60afa29860822d3fc",
+    "zh:fa7ce69dde358e172bd719014ad637634bbdabc49363104f4fca759b4b73f2ce",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/template" {
+  version     = "2.2.0"
+  constraints = "~> 2.2"
+  hashes = [
+    "h1:94qn780bi1qjrbC3uQtjJh3Wkfwd5+tTtJHOb7KTg9w=",
+    "zh:01702196f0a0492ec07917db7aaa595843d8f171dc195f4c988d2ffca2a06386",
+    "zh:09aae3da826ba3d7df69efeb25d146a1de0d03e951d35019a0f80e4f58c89b53",
+    "zh:09ba83c0625b6fe0a954da6fbd0c355ac0b7f07f86c91a2a97849140fea49603",
+    "zh:0e3a6c8e16f17f19010accd0844187d524580d9fdb0731f675ffcf4afba03d16",
+    "zh:45f2c594b6f2f34ea663704cc72048b212fe7d16fb4cfd959365fa997228a776",
+    "zh:77ea3e5a0446784d77114b5e851c970a3dde1e08fa6de38210b8385d7605d451",
+    "zh:8a154388f3708e3df5a69122a23bdfaf760a523788a5081976b3d5616f7d30ae",
+    "zh:992843002f2db5a11e626b3fc23dc0c87ad3729b3b3cff08e32ffb3df97edbde",
+    "zh:ad906f4cebd3ec5e43d5cd6dc8f4c5c9cc3b33d2243c89c5fc18f97f7277b51d",
+    "zh:c979425ddb256511137ecd093e23283234da0154b7fa8b21c2687182d9aea8b2",
+  ]
+}

--- a/workload-1/infra/main.tf
+++ b/workload-1/infra/main.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_providers {
+    local = {
+      source = "hashicorp/local"
+      version = "~> 2.4"
+    }
+    template = {
+      source = "hashicorp/template"
+      version = "~> 2.2"
+    }
+  }
+}

--- a/workload-1/infra/templated-manifests.tf
+++ b/workload-1/infra/templated-manifests.tf
@@ -1,0 +1,11 @@
+resource "local_file" "destination_rule" {
+  filename = "${path.module}/../config/destination-rule.yaml"
+  content  = data.template_file.destination_rule.rendered
+}
+
+data "template_file" "destination_rule" {
+  template = file("${path.module}/templates/destination-rule.yaml")
+  vars = {
+    spire_trust_domain = var.spire_trust_domain
+  }
+}

--- a/workload-1/infra/templates/destination-rule.yaml
+++ b/workload-1/infra/templates/destination-rule.yaml
@@ -1,0 +1,11 @@
+apiVersion: networking.istio.io/v1beta1
+kind: DestinationRule
+metadata:
+  name: workload-1-custom-spire-destrule
+spec:
+  host: workload-1
+  trafficPolicy:
+    tls:
+      mode: ISTIO_MUTUAL
+      subjectAltNames:
+      - spiffe://${spire_trust_domain}/workload-1

--- a/workload-1/infra/variables.tf
+++ b/workload-1/infra/variables.tf
@@ -1,0 +1,3 @@
+variable "spire_trust_domain" {
+  default = "controlplane.io"
+}

--- a/workload-2/Makefile
+++ b/workload-2/Makefile
@@ -1,3 +1,18 @@
+deploy: terraform-apply apply
+
+clean: delete terraform-destroy
+
+terraform-apply:
+	cd infra && \
+		$(TERRAFORM) init && \
+		$(TERRAFORM) apply \
+		-var spire_trust_domain=$(SPIRE_TRUST_DOMAIN) \
+		-auto-approve
+
+terraform-destroy:
+	cd infra && $(TERRAFORM) apply -auto-approve -destroy
+
+
 apply:
 	kubectl apply -f config
 

--- a/workload-2/infra/.terraform.lock.hcl
+++ b/workload-2/infra/.terraform.lock.hcl
@@ -1,0 +1,40 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/local" {
+  version     = "2.4.0"
+  constraints = "~> 2.4"
+  hashes = [
+    "h1:R97FTYETo88sT2VHfMgkPU3lzCsZLunPftjSI5vfKe8=",
+    "zh:53604cd29cb92538668fe09565c739358dc53ca56f9f11312b9d7de81e48fab9",
+    "zh:66a46e9c508716a1c98efbf793092f03d50049fa4a83cd6b2251e9a06aca2acf",
+    "zh:70a6f6a852dd83768d0778ce9817d81d4b3f073fab8fa570bff92dcb0824f732",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:82a803f2f484c8b766e2e9c32343e9c89b91997b9f8d2697f9f3837f62926b35",
+    "zh:9708a4e40d6cc4b8afd1352e5186e6e1502f6ae599867c120967aebe9d90ed04",
+    "zh:973f65ce0d67c585f4ec250c1e634c9b22d9c4288b484ee2a871d7fa1e317406",
+    "zh:c8fa0f98f9316e4cfef082aa9b785ba16e36ff754d6aba8b456dab9500e671c6",
+    "zh:cfa5342a5f5188b20db246c73ac823918c189468e1382cb3c48a9c0c08fc5bf7",
+    "zh:e0e2b477c7e899c63b06b38cd8684a893d834d6d0b5e9b033cedc06dd7ffe9e2",
+    "zh:f62d7d05ea1ee566f732505200ab38d94315a4add27947a60afa29860822d3fc",
+    "zh:fa7ce69dde358e172bd719014ad637634bbdabc49363104f4fca759b4b73f2ce",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/template" {
+  version     = "2.2.0"
+  constraints = "~> 2.2"
+  hashes = [
+    "h1:94qn780bi1qjrbC3uQtjJh3Wkfwd5+tTtJHOb7KTg9w=",
+    "zh:01702196f0a0492ec07917db7aaa595843d8f171dc195f4c988d2ffca2a06386",
+    "zh:09aae3da826ba3d7df69efeb25d146a1de0d03e951d35019a0f80e4f58c89b53",
+    "zh:09ba83c0625b6fe0a954da6fbd0c355ac0b7f07f86c91a2a97849140fea49603",
+    "zh:0e3a6c8e16f17f19010accd0844187d524580d9fdb0731f675ffcf4afba03d16",
+    "zh:45f2c594b6f2f34ea663704cc72048b212fe7d16fb4cfd959365fa997228a776",
+    "zh:77ea3e5a0446784d77114b5e851c970a3dde1e08fa6de38210b8385d7605d451",
+    "zh:8a154388f3708e3df5a69122a23bdfaf760a523788a5081976b3d5616f7d30ae",
+    "zh:992843002f2db5a11e626b3fc23dc0c87ad3729b3b3cff08e32ffb3df97edbde",
+    "zh:ad906f4cebd3ec5e43d5cd6dc8f4c5c9cc3b33d2243c89c5fc18f97f7277b51d",
+    "zh:c979425ddb256511137ecd093e23283234da0154b7fa8b21c2687182d9aea8b2",
+  ]
+}

--- a/workload-2/infra/main.tf
+++ b/workload-2/infra/main.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_providers {
+    local = {
+      source = "hashicorp/local"
+      version = "~> 2.4"
+    }
+    template = {
+      source = "hashicorp/template"
+      version = "~> 2.2"
+    }
+  }
+}

--- a/workload-2/infra/templated-manifests.tf
+++ b/workload-2/infra/templated-manifests.tf
@@ -1,0 +1,11 @@
+resource "local_file" "destination_rule" {
+  filename = "${path.module}/../config/destination-rule.yaml"
+  content  = data.template_file.destination_rule.rendered
+}
+
+data "template_file" "destination_rule" {
+  template = file("${path.module}/templates/destination-rule.yaml")
+  vars = {
+    spire_trust_domain = var.spire_trust_domain
+  }
+}

--- a/workload-2/infra/templates/destination-rule.yaml
+++ b/workload-2/infra/templates/destination-rule.yaml
@@ -1,0 +1,11 @@
+apiVersion: networking.istio.io/v1beta1
+kind: DestinationRule
+metadata:
+  name: workload-2-custom-spire-destrule
+spec:
+  host: workload-2
+  trafficPolicy:
+    tls:
+      mode: ISTIO_MUTUAL
+      subjectAltNames:
+      - spiffe://${spire_trust_domain}/workload-2

--- a/workload-2/infra/variables.tf
+++ b/workload-2/infra/variables.tf
@@ -1,0 +1,3 @@
+variable "spire_trust_domain" {
+  default = "controlplane.io"
+}


### PR DESCRIPTION
- modify cluster spiffe ids to use custom format
- modify federation trust relationships to use new ids
- add templated destination rule to workloads 1 and 2 with a DestinationRule as suggested in https://github.com/istio/istio/issues/43105 